### PR TITLE
fixed deployment success/fail message and loging to step summary

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -22,6 +22,8 @@ jobs:
       run: npm install -g @railway/cli
 
     - name: Deploy to Railway
+      id: deploy
+      continue-on-error: true
       run: railway up --service=${{ secrets.RAILWAY_SERVICE_ID }}
       env:
         RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
@@ -33,7 +35,7 @@ jobs:
           echo '# Railway Deployment'
           echo ''
           echo '## Status'
-          if [ $? -eq 0 ]; then
+          if [ "${{ steps.deploy.outcome }}" == "success" ]; then
             echo '✅ Deployment successful'
           else
             echo '❌ Deployment failed'


### PR DESCRIPTION
Had initial failure of CD pipeline, Step summary still gave the success message. CD failure was actually due to using wrong railway tokens, now fixed. 
closes: #78 